### PR TITLE
Add 'Wake without Unlocking' functionality

### DIFF
--- a/BLEUnlock/Base.lproj/Localizable.strings
+++ b/BLEUnlock/Base.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "Unlock RSSI";
 "use_screensaver_to_lock" = "Use Screensaver to Lock";
 "wake_on_proximity" = "Wake on Proximity";
+"wake_without_unlocking" = "Wake without Unlocking";

--- a/BLEUnlock/Info.plist
+++ b/BLEUnlock/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>1.11</string>
 	<key>CFBundleVersion</key>
-	<string>764</string>
+	<string>766</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/BLEUnlock/da.lproj/Localizable.strings
+++ b/BLEUnlock/da.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "Låse op RSSI";
 "use_screensaver_to_lock" = "Brug screensaver til at låse";
 "wake_on_proximity" = "Vågn op på nærhed";
+"wake_without_unlocking" = "Vågn op uden at låse op";

--- a/BLEUnlock/de.lproj/Localizable.strings
+++ b/BLEUnlock/de.lproj/Localizable.strings
@@ -35,3 +35,4 @@
 "unlock_rssi" = "RSSI entsperren";
 "use_screensaver_to_lock" = "Den Bildschirmschoner verwenden zum Sperren";
 "wake_on_proximity" = "Aufwachen bei Annäherung";
+"wake_without_unlocking" = "Aufwachen ohne Entsperren";

--- a/BLEUnlock/ja.lproj/Localizable.strings
+++ b/BLEUnlock/ja.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "アンロック信号強度";
 "use_screensaver_to_lock" = "スクリーンセーバーでロック";
 "wake_on_proximity" = "画面スリープから復帰";
+"wake_without_unlocking" = "ロックを解除せずに目を覚ます";

--- a/BLEUnlock/nb.lproj/Localizable.strings
+++ b/BLEUnlock/nb.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "Låse opp RSSI";
 "use_screensaver_to_lock" = "Bruke skjermsparer til å låse";
 "wake_on_proximity" = "Vekk ved nærhet";
+"wake_without_unlocking" = "Våkne uten å låse opp";

--- a/BLEUnlock/sv.lproj/Localizable.strings
+++ b/BLEUnlock/sv.lproj/Localizable.strings
@@ -34,4 +34,4 @@
 "unlock_rssi" = "Lås upp RSSI";
 "use_screensaver_to_lock" = "Använd skärmsläckare för att låsa";
 "wake_on_proximity" = "Väckning om in närheten";
-
+"wake_without_unlocking" = "Vakna utan att låsa upp";

--- a/BLEUnlock/tr.lproj/Localizable.strings
+++ b/BLEUnlock/tr.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "Kilit açma RSSI";
 "use_screensaver_to_lock" = "Kilit ekranı için ekran kuruyucu kullan";
 "wake_on_proximity" = "Uyandırma yakınlığı";
+"wake_without_unlocking" = "Kilidi açmadan uyanın";

--- a/BLEUnlock/zh-Hans.lproj/Localizable.strings
+++ b/BLEUnlock/zh-Hans.lproj/Localizable.strings
@@ -34,3 +34,4 @@
 "unlock_rssi" = "解锁 RSSI";
 "use_screensaver_to_lock" = "用屏保来锁定它";
 "wake_on_proximity" = "靠近唤醒";
+"wake_without_unlocking" = "唤醒时不需解锁";

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Lock RSSI | Bluetooth signal strength to lock. Smaller value indicates that the 
 Delay to Lock | Duration of time before it locks the Mac when it detects that the BLE device is away. If the BLE device comes closer within that time, no lock will occur.
 No-Signal Timeout | Time between last signal reception and locking. If you experience frequent "Signal is lost" locking, increase this value.
 Wake on Proximity | Wakes up the display from sleep when the BLE device approaches while locking.
+Wake without Unlocking | BLEUnlock will not unlock the Mac when the display wakes up from sleep, whether automatically via "Wake on Proximity" or manually. This allows for compatibility with the macOS built-in unlock with Apple Watch feature (which can operate immediately after BLEUnlock wakes the screen), or if you just prefer the lock screen to appear more quickly but don't want it to auto-unlock.
 Pause "Now Playing" while Locked | On lock/unlock, BLEUnlock pauses/unpauses playback of music or video (including Apple Music, QuickTime Player and Spotify) that is controlled by *Now Playing* widget or the ⏯ key on the keyboard.
 Use Screensaver to Lock | If this option is set, BLEUnlock launches screensaver instead of locking. For this option to work properly, you need to set *Require password **immediately** after sleep or screen saver begins* option in *Security & Privacy* preference pane.
 Set Password... | If you changed your login password, use this.


### PR DESCRIPTION
This adds the option to prevent BLEUnlock from automatically unlocking the Mac when the screen wakes up, whether it be via the Wake on Proximity option or manually otherwise.

In conjunction with Wake on Proximity, this is especially useful when combined with the macOS built-in unlock with Apple Watch feature for more security (since macOS also checks that you are wearing the watch and that the watch is already unlocked), or if one simply prefers the lock screen to appear before they walk to their Mac, but doesn't want a full automatic unlock.

PS: I can only confirm that the localisations for this new feature in English and Chinese should be correct, but not the others.