### PR TITLE
Add toggle to also run the event script while locked

### DIFF
--- a/BLEUnlock/Base.lproj/Localizable.strings
+++ b/BLEUnlock/Base.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Your password will be securely stored in Keychain.";
 "password_not_set" = "Password is not set.";
 "pause_now_playing" = "Pause \"Now Playing\" while Locked";
+"run_event_script_while_locked" = "Run \"event\" Script while Locked";
 "quit" = "Quit BLEUnlock";
 "scanning" = "Scanning…";
 "seconds" = "seconds";

--- a/BLEUnlock/da.lproj/Localizable.strings
+++ b/BLEUnlock/da.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Din adgangskode vil blive gemt sikkert i nøglering.";
 "password_not_set" = "Der er ikke indstillet et kodeord.";
 "pause_now_playing" = "Pause \"Afspilning nu\", mens den er låst";
+"run_event_script_while_locked" = "Kør \"event\"-scriptet, mens den er låst";
 "quit" = "Afslut BLEUnlock";
 "scanning" = "Scanning…";
 "seconds" = "seconder";

--- a/BLEUnlock/de.lproj/Localizable.strings
+++ b/BLEUnlock/de.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Das Passwort wurde sicher am Schlüsselbund gespeichert.";
 "password_not_set" = "Kein Passwort gesetzt.";
 "pause_now_playing" = "Pause \"Spielt jetzt\" während der Sperre";
+"run_event_script_while_locked" = "\"event\"-Skript während der Sperre ausführen";
 "quit" = "BLEUnlock beenden";
 "scanning" = "Scanning";
 "seconds" = "seconds";

--- a/BLEUnlock/ja.lproj/Localizable.strings
+++ b/BLEUnlock/ja.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "パスワードはキーチェーンに安全に保存されます。";
 "password_not_set" = "パスワードが設定されていません。";
 "pause_now_playing" = "ロック中 \"再生中\" を一時停止";
+"run_event_script_while_locked" = "ロック中に \"event\" スクリプトを実行";
 "quit" = "BLEUnlock を終了";
 "scanning" = "スキャン中…";
 "seconds" = "秒";

--- a/BLEUnlock/nb.lproj/Localizable.strings
+++ b/BLEUnlock/nb.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Passordet lagres sikkert i nøkkelringen.";
 "password_not_set" = "Passord er ikke angitt.";
 "pause_now_playing" = "Stans \"Avspilling nå\" mens den er låst";
+"run_event_script_while_locked" = "Kjør \"event\"-skriptet mens den er låst";
 "quit" = "Slutte BLEUnlock";
 "scanning" = "kcanning…";
 "seconds" = "seconder";

--- a/BLEUnlock/sv.lproj/Localizable.strings
+++ b/BLEUnlock/sv.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Ditt lösenord lagras säkert i nyckelringen.";
 "password_not_set" = "Inget lösenordet har angetts.";
 "pause_now_playing" = "Pausa \"Spela nu\" när låst";
+"run_event_script_while_locked" = "Kör \"event\"-skript när låst";
 "quit" = "Avsluta BLEUnlock";
 "scanning" = "Skannar…";
 "seconds" = "sekunder";

--- a/BLEUnlock/tr.lproj/Localizable.strings
+++ b/BLEUnlock/tr.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "Şifreniz güvenli bir şekilde anahtar zincirinde saklanacaktır.";
 "password_not_set" = "Şifre belirlenmedi.";
 "pause_now_playing" = "Kilitliyken \"Now Playing\" beklet";
+"run_event_script_while_locked" = "Kilitliyken \"event\" betiğini çalıştır";
 "quit" = "BLEUnlock'tan çıkış";
 "scanning" = "Taranıyor…";
 "seconds" = "saniye";

--- a/BLEUnlock/zh-Hans.lproj/Localizable.strings
+++ b/BLEUnlock/zh-Hans.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "password_info" = "您的密码将安全地存储在钥匙串中。";
 "password_not_set" = "密码未设置。";
 "pause_now_playing" = "锁定时暂停\"播放中\"";
+"run_event_script_while_locked" = "锁定时运行 \"event\" 脚本";
 "quit" = "退出BLEUnlock";
 "scanning" = "扫描中…";
 "seconds" = "秒钟";

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ No-Signal Timeout | Time between last signal reception and locking. If you exper
 Wake on Proximity | Wakes up the display from sleep when the BLE device approaches while locking.
 Wake without Unlocking | BLEUnlock will not unlock the Mac when the display wakes up from sleep, whether automatically via "Wake on Proximity" or manually. This allows for compatibility with the macOS built-in unlock with Apple Watch feature (which can operate immediately after BLEUnlock wakes the screen), or if you just prefer the lock screen to appear more quickly but don't want it to auto-unlock.
 Pause "Now Playing" while Locked | On lock/unlock, BLEUnlock pauses/unpauses playback of music or video (including Apple Music, QuickTime Player and Spotify) that is controlled by *Now Playing* widget or the ⏯ key on the keyboard.
+Run "event" Script while Locked | If the screen is already locked (for example, the user locks it manually and then walks away), the event script still runs. When this option is disabled, the event script runs only when BLEUnlock itself locks the screen (default behavior).
 Use Screensaver to Lock | If this option is set, BLEUnlock launches screensaver instead of locking. For this option to work properly, you need to set *Require password **immediately** after sleep or screen saver begins* option in *Security & Privacy* preference pane.
 Turn Off Screen on Lock | Turn off the display immediately when locking.
 Set Password... | If you changed your login password, use this.


### PR DESCRIPTION
It's sometimes useful to always have the event script running when moving away, regardless of if the screen is already locked or not. This pull request adds a toggle to enable this behaviour if required. The default behaviour stays the same (option unchecked).