### PR TITLE
Fix incorrect variable reference in parse_info()

### DIFF
--- a/apple-device-names
+++ b/apple-device-names
@@ -9,7 +9,7 @@ def parse_info(filename):
     p = Popen([
         'plutil',
         '-convert', 'json',
-        f,
+        filename,
         '-o', '-'
     ], stdout=PIPE)
 


### PR DESCRIPTION
The function parse_info() accepts a filename argument but uses the
external variable `f` when invoking plutil.

This makes the function depend on a variable from outer scope and can
raise NameError if called independently.

Use the function parameter `filename` instead.